### PR TITLE
fix: image uri load

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,5 @@ yarn-error.*
 
 # typescript
 *.tsbuildinfo
+
+yarn.lock

--- a/WatermarkTest.ts
+++ b/WatermarkTest.ts
@@ -1,12 +1,12 @@
 import Marker, { Position, ImageFormat } from "react-native-image-marker"
 import { ImageSource } from 'expo-image';
+import { Platform } from 'react-native';
 
 const wmImage = require('./assets/wm.png');
 
 export const imageWithMark = async (bgImage: string | ImageSource | null) => {
     if (!bgImage)
         return null;
-
 
     const url = await Marker.markImage({
         backgroundImage: {
@@ -22,5 +22,5 @@ export const imageWithMark = async (bgImage: string | ImageSource | null) => {
         saveFormat: ImageFormat.jpg
     })
 
-    return `file:${url}`;
+    return  Platform.OS === 'android'? `file:${url}` : url;
 };

--- a/app.json
+++ b/app.json
@@ -41,6 +41,14 @@
         {
           "photosPermission": "The app accesses your photos to let you share them with your friends."
         }
+      ],
+      [
+        "expo-media-library",
+        {
+          "photosPermission": "Allow $(PRODUCT_NAME) to access your photos.",
+          "savePhotosPermission": "Allow $(PRODUCT_NAME) to save photos.",
+          "isAccessMediaLocationEnabled": true
+        }
       ]
     ],
     "extra": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "expo/tsconfig.base",
   "compilerOptions": {
+    "jsx": "react",
     "strict": true
   }
 }


### PR DESCRIPTION
this is a temporary solution for https://github.com/JimmyDaddy/react-native-image-marker/discussions/214

If no specific width and height are set for the image, Coil will use the resolution of the current device to set the width and height of the image to optimize image loading. This results in the image not maintaining its original dimensions.

ref: https://github.com/JimmyDaddy/react-native-image-marker/blob/27b6f40204d154fdea21abedae23f9388e5521c2/android/src/main/java/com/jimmydaddy/imagemarker/MarkerImageLoader.kt#L56